### PR TITLE
Tokenline improvements

### DIFF
--- a/tokenline.c
+++ b/tokenline.c
@@ -28,6 +28,7 @@
 static void line_clear(t_tokenline *tl);
 static void line_backspace(t_tokenline *tl);
 static void set_line(t_tokenline *tl, char *line);
+static void add_char(t_tokenline *tl, int c);
 static void add_char_silent(t_tokenline *tl, int c);
 static char space[] = "               ";
 
@@ -506,6 +507,15 @@ static int tokenize(t_tokenline *tl, int *words, int num_words,
 						cur_bufsize += 2;
 					} else {
 						tl->print(tl->user, "Invalid command."NL);
+						for (i = 0; i < num_words; i++) {
+							tl->print(tl->user, tl->buf + words[i]);
+							tl->print(tl->user, " ");
+						}
+						tl->print(tl->user,NL);
+						for(i=0; i < words[w];i++){
+							tl->print(tl->user,"-");
+						}
+						tl->print(tl->user,"^"NL);
 						return FALSE;
 					}
 				} else {

--- a/tokenline.c
+++ b/tokenline.c
@@ -495,18 +495,19 @@ static int tokenize(t_tokenline *tl, int *words, int num_words,
 				}
 				if (token_stack[cur_tsp][i].token) {
 					/* Add it in as a token. */
-					p->tokens[cur_tp++] = T_ARG_STRING;
-					if (word[0] != '"') {
-						p->tokens[cur_tp++] = cur_bufsize;
-						size = strlen(word) + 1;
-						memcpy(p->buf + cur_bufsize, word, size);
-					} else {
+					if (word[0] == '"' && word[1] != 0) {
+						p->tokens[cur_tp++] = T_ARG_STRING;
 						p->tokens[cur_tp++] = cur_bufsize + 1;
-    						size = strlen(word+1) + 1;
-	    					memcpy(p->buf + cur_bufsize + 1, word + 1, size);
+						size = strlen(word + 1) + 1;
+						memcpy(p->buf + cur_bufsize + 1, word + 1, size);
+						cur_bufsize += size;
+						p->buf[cur_bufsize] = 0;
+					} else if (word[0] == '"' && word[1] == 0){
+						cur_bufsize += 2;
+					} else {
+						tl->print(tl->user, "Invalid command."NL);
+						return FALSE;
 					}
-					cur_bufsize += size;
-					p->buf[cur_bufsize] = 0;
 				} else {
 					if (!complete_tokens)
 						tl->print(tl->user, "Invalid command."NL);

--- a/tokenline.c
+++ b/tokenline.c
@@ -134,7 +134,12 @@ static void history_up(t_tokenline *tl)
 	if (entry == -1)
 		return;
 	line_clear(tl);
-	set_line(tl, tl->hist_buf + entry);
+	if (tl->hist_begin != 0 && TL_MAX_HISTORY_SIZE == strlen(tl->hist_buf + entry) + entry) {
+		set_line(tl, tl->hist_buf + entry);
+		set_line(tl, tl->hist_buf);
+	} else {
+		set_line(tl, tl->hist_buf + entry);
+	}
 	tl->hist_step = entry;
 }
 

--- a/tokenline.c
+++ b/tokenline.c
@@ -23,28 +23,13 @@
 #define INDENT   "   "
 #define NO_HELP  "No help available."NL
 #define NL       "\r\n"
-#define CHARS	 "[]{}/\\_-!^.&%~" 
+#define HYDRABUS_SPECIAL_CHARS	 "[]{}/\\_-!^.&%~" 
 
 static void line_clear(t_tokenline *tl);
 static void line_backspace(t_tokenline *tl);
 static void set_line(t_tokenline *tl, char *line);
-
+static void add_char_silent(t_tokenline *tl, int c);
 static char space[] = "               ";
-
-static void add_charz(t_tokenline *tl, int c)
-{
-	if (tl->pos == tl->buf_len) {
-		tl->buf[tl->buf_len++] = c;
-		tl->buf[tl->buf_len] = 0;
-		tl->pos++;
-	} else {
-		memmove(tl->buf + tl->pos + 1, tl->buf + tl->pos,
-				tl->buf_len - tl->pos + 1);
-		tl->buf[tl->pos] = c;
-		tl->buf_len++;
-		tl->pos++;
-	}
-}
 
 static void unsplit_line(t_tokenline *tl)
 {
@@ -84,11 +69,11 @@ static int split_line(t_tokenline *tl, int *words, int *num_words, int silent)
 			if (tl->buf[i] == '"')
 				quoted = TRUE;
 
-			if (!quoted && strchr(CHARS, tl->buf[i])) {
-				if(tl->buf[i+1] != '\x20' && tl->buf[i+1] != 0 && tl->buf[i+1] != ':' && i < tl->buf_len) {
+			if (!quoted && strchr(HYDRABUS_SPECIAL_CHARS, tl->buf[i])) {
+				if(tl->buf[i+1] != ' ' && tl->buf[i+1] != 0 && tl->buf[i+1] != ':' && i < tl->buf_len) {
 					if((tl->buf_len+2 <= TL_MAX_LINE_LEN) && (*num_words+1 <=TL_MAX_WORDS)){
 						tl->pos=i+1;
-						add_charz(tl, '\x20');
+						add_char_silent(tl, ' ');
 					} else {
 						tl->print(tl->user, "Too much tokens."NL);
 						unsplit_line(tl);
@@ -109,11 +94,11 @@ static int split_line(t_tokenline *tl, int *words, int *num_words, int silent)
 						tokened = TRUE;
 					}
 				}
-				if (!tokened && strchr(CHARS, tl->buf[i])){
-					if (tl->buf[i-1] != '\x20' && tl->buf[i-1] != 0 && tl->buf[i-1] != ':' && i < tl->buf_len){
+				if (!tokened && strchr(HYDRABUS_SPECIAL_CHARS, tl->buf[i])){
+					if (tl->buf[i-1] != ' ' && tl->buf[i-1] != 0 && tl->buf[i-1] != ':' && i < tl->buf_len){
 						if((tl->buf_len+2 <= TL_MAX_LINE_LEN) && (*num_words+1 <= TL_MAX_WORDS)){
 							tl->pos=i;
-							add_charz(tl, '\x20');
+							add_char_silent(tl, ' ');
 						} else {
 							tl->print(tl->user, "Too much tokens."NL);
 							unsplit_line(tl);
@@ -749,6 +734,21 @@ static void process_line(t_tokenline *tl)
 	tl->pos = 0;
 	tl->hist_step = -1;
 	tl->print(tl->user, tl->prompt);
+}
+
+static void add_char_silent(t_tokenline *tl, int c)
+{
+	if (tl->pos == tl->buf_len) {
+		tl->buf[tl->buf_len++] = c;
+		tl->buf[tl->buf_len] = 0;
+		tl->pos++;
+	} else {
+		memmove(tl->buf + tl->pos + 1, tl->buf + tl->pos,
+				tl->buf_len - tl->pos + 1);
+		tl->buf[tl->pos] = c;
+		tl->buf_len++;
+		tl->pos++;
+	}
 }
 
 static void add_char(t_tokenline *tl, int c)

--- a/tokenline.c
+++ b/tokenline.c
@@ -511,11 +511,11 @@ static int tokenize(t_tokenline *tl, int *words, int num_words,
 							tl->print(tl->user, tl->buf + words[i]);
 							tl->print(tl->user, " ");
 						}
-						tl->print(tl->user,NL);
-						for(i=0; i < words[w];i++){
-							tl->print(tl->user,"-");
+						tl->print(tl->user, NL);
+						for(i = 0; i < words[w]; i++){
+							tl->print(tl->user, "-");
 						}
-						tl->print(tl->user,"^"NL);
+						tl->print(tl->user, "^"NL);
 						return FALSE;
 					}
 				} else {

--- a/tokenline.c
+++ b/tokenline.c
@@ -456,7 +456,7 @@ static int tokenize(t_tokenline *tl, int *words, int num_words,
 				suffix_uint = 0;
 			}
 
-			if ((t_idx = find_token(token_stack[cur_tsp], tl->token_dict, word)) > -1 && word[0] != 0x22) {
+			if ((t_idx = find_token(token_stack[cur_tsp], tl->token_dict, word)) > -1 && word[0] != '"') {
 				t = token_stack[cur_tsp][t_idx].token;
 				p->tokens[cur_tp++] = t;
 				if (t == T_ARG_UINT) {
@@ -511,7 +511,7 @@ static int tokenize(t_tokenline *tl, int *words, int num_words,
 				if (token_stack[cur_tsp][i].token) {
 					/* Add it in as a token. */
 					p->tokens[cur_tp++] = T_ARG_STRING;
-					if (word[0] != 0x22) {
+					if (word[0] != '"') {
 						p->tokens[cur_tp++] = cur_bufsize;
 						size = strlen(word) + 1;
 						memcpy(p->buf + cur_bufsize, word, size);
@@ -600,7 +600,7 @@ static int tokenize(t_tokenline *tl, int *words, int num_words,
 				break;
 			case T_ARG_STRING:
 				p->tokens[cur_tp++] = T_ARG_STRING;
-				if (word[0] != 0x22) {
+				if (word[0] != '"') {
 					p->tokens[cur_tp++] = cur_bufsize;
 					size = strlen(word) + 1;
 					memcpy(p->buf + cur_bufsize, word, size);
@@ -608,7 +608,7 @@ static int tokenize(t_tokenline *tl, int *words, int num_words,
 					p->tokens[cur_tp++] = cur_bufsize + 1;
 					size = strlen(word + 1) + 1;
 					memcpy(p->buf + cur_bufsize + 1, word + 1, size);
-					}
+				}
 				cur_bufsize += size;
 				p->buf[cur_bufsize] = 0;
 				break;


### PR DESCRIPTION
Hey,

This commit aims to fix some issues in tokenline which could happen when such command was sent to Hydrabus : 

> spi1> [0x3a 0x0f [0x3b r]
WRITE: 0x5B 0x30 0x78 0x33 0x61 
WRITE: 0x0F
WRITE: 0x5B 0x30 0x78 0x33 0x62 
WRITE: 0x72 0x5D

Because of the missing spaces, tokenline was unable to parse it correctly. With this patch :
>spi1> [0x3a 0x0f [0x3b r]
/CS ENABLED
WRITE: 0x3A 0x0F 
/CS ENABLED
WRITE: 0x3B
READ: 0xFF
/CS DISABLED

One of the good side effect happens when the user hit "Tab" execute the command and history up, the command will magically transform into: 
> [ 0x3a 0x0f [ 0x3b r ]

While debugging I found another bug with the ":" delimiter which was stripped from the CLI when hitting  "Tab"
> spi1> %:5 
   show           Show SPI parameters
   trigger        Setup SPI trigger
   device         SPI device (1/2)
   pull           GPIO pull (up/down/floating)
   mode           Mode (master/slave)
   frequency      Bus frequency
   polarity       Clock polarity (0/1)
   phase          Clock phase (0/1)
   msb-first      Send/receive MSB first
   lsb-first      Send/receive LSB first
   read           Read byte (repeat with :<num>)
   hd             Read byte (repeat with :<num>) and print hexdump
   write          Write byte (repeat with :<num>)
   <integer>      Write byte (repeat with :<num>)
   <string>       Write string
   cs-on          Alias for "chip-select on"
   cs-off         Alias for "chip-select off"
   [              Alias for "chip-select on"
   ]              Alias for "chip-select off"
   &              Delay 1 usec (repeat with :<num>)
   %              Delay 1 msec (repeat with :<num>)
   ~              Write a random byte (repeat with :<num>)
   exit           Exit SPI mode
spi1> % 5 

The reason was that the ":" delimiter was stripped during token identification and never put back.

Extensive testing has ben perfomed on this patch, but to prevent any further issues, please review/test before merging.

Cheers
