### PR TITLE
Tokenline Improvements part 2

### DIFF
--- a/tokenline.c
+++ b/tokenline.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Bert Vermeulen <bert@biot.com>
+ * Copyright (C) 2019 Karim SUDKI
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -96,7 +97,7 @@ static int split_line(t_tokenline *tl, int *words, int *num_words, int silent)
 						tokened = TRUE;
 					}
 				}
-				if (!tokened && strchr(HYDRABUS_SPECIAL_CHARS, tl->buf[i])){
+				if (!tokened && (strchr(HYDRABUS_SPECIAL_CHARS, tl->buf[i]) || tl->buf[i] == '"')){
 					if (tl->buf[i-1] != ' ' && tl->buf[i-1] != 0 && tl->buf[i-1] != ':') {
 						if((tl->buf_len + 1 < TL_MAX_LINE_LEN) && (*num_words + 1 < TL_MAX_WORDS)){
 							tl->pos=i;

--- a/tokenline.c
+++ b/tokenline.c
@@ -72,13 +72,9 @@ static int split_line(t_tokenline *tl, int *words, int *num_words, int silent)
 
 			if (!quoted && strchr(HYDRABUS_SPECIAL_CHARS, tl->buf[i])) {
 				if(tl->buf[i+1] != ' ' && tl->buf[i+1] != 0 && tl->buf[i+1] != ':' && i < tl->buf_len) {
-					if((tl->buf_len+2 <= TL_MAX_LINE_LEN) && (*num_words+1 <=TL_MAX_WORDS)){
+					if((tl->buf_len + 1 < TL_MAX_LINE_LEN - 1) && (*num_words + 1 < TL_MAX_WORDS)){
 						tl->pos=i+1;
 						add_char_silent(tl, ' ');
-					} else {
-						tl->print(tl->user, "Too much tokens."NL);
-						unsplit_line(tl);
-						return FALSE;
 					}
 				}
 			}
@@ -97,13 +93,9 @@ static int split_line(t_tokenline *tl, int *words, int *num_words, int silent)
 				}
 				if (!tokened && strchr(HYDRABUS_SPECIAL_CHARS, tl->buf[i])){
 					if (tl->buf[i-1] != ' ' && tl->buf[i-1] != 0 && tl->buf[i-1] != ':' && i < tl->buf_len){
-						if((tl->buf_len+2 <= TL_MAX_LINE_LEN) && (*num_words+1 <= TL_MAX_WORDS)){
+						if((tl->buf_len + 1 < TL_MAX_LINE_LEN) && (*num_words + 1 < TL_MAX_WORDS)){
 							tl->pos=i;
 							add_char_silent(tl, ' ');
-						} else {
-							tl->print(tl->user, "Too much tokens."NL);
-							unsplit_line(tl);
-							return FALSE;
 						}
 					}
 				} 
@@ -126,7 +118,7 @@ static int split_line(t_tokenline *tl, int *words, int *num_words, int silent)
 		unsplit_line(tl);
 		return FALSE;
 	}
-	if (*num_words > TL_MAX_WORDS) {
+	if (*num_words > TL_MAX_WORDS - 1) {
 		if (!silent)
 			tl->print(tl->user, "Too many words."NL);
 		unsplit_line(tl);
@@ -444,10 +436,18 @@ static int tokenize(t_tokenline *tl, int *words, int num_words,
 
 			if ((t_idx = find_token(token_stack[cur_tsp], tl->token_dict, word)) > -1 && word[0] != '"') {
 				t = token_stack[cur_tsp][t_idx].token;
+				if (!(cur_tp + 1 < TL_MAX_WORDS)){
+					tl->print(tl->user, "Too many words."NL);
+					return FALSE;
+				}
 				p->tokens[cur_tp++] = t;
 				if (t == T_ARG_UINT) {
 					/* Integer token. */
 					str_to_uint(word, &arg_uint, NULL);
+					if (!(cur_tp + 1 < TL_MAX_WORDS)){
+						tl->print(tl->user, "Too many words."NL);
+						return FALSE;
+					}
 					p->tokens[cur_tp++] = cur_bufsize;
 					memcpy(p->buf + cur_bufsize, &arg_uint, sizeof(uint32_t));
 					cur_bufsize += sizeof(uint32_t);
@@ -460,6 +460,10 @@ static int tokenize(t_tokenline *tl, int *words, int num_words,
 						return FALSE;
 					}
 					if (suffix_uint > 1) {
+						if (!(cur_tp + 2 < TL_MAX_WORDS)){
+							tl->print(tl->user, "Too many words."NL);
+							return FALSE;
+						}
 						p->tokens[cur_tp++] = T_ARG_TOKEN_SUFFIX_INT;
 						p->tokens[cur_tp++] = cur_bufsize;
 						memcpy(p->buf + cur_bufsize, &suffix_uint, sizeof(uint32_t));
@@ -497,6 +501,10 @@ static int tokenize(t_tokenline *tl, int *words, int num_words,
 				if (token_stack[cur_tsp][i].token) {
 					/* Add it in as a token. */
 					if (word[0] == '"' && word[1] != 0) {
+						if (!(cur_tp + 2 < TL_MAX_WORDS)){
+							tl->print(tl->user, "Too many words."NL);
+							return FALSE;
+						}
 						p->tokens[cur_tp++] = T_ARG_STRING;
 						p->tokens[cur_tp++] = cur_bufsize + 1;
 						size = strlen(word + 1) + 1;
@@ -552,6 +560,10 @@ static int tokenize(t_tokenline *tl, int *words, int num_words,
 						return FALSE;
 					}
 				}
+				if (!(cur_tp + 2 < TL_MAX_WORDS)){
+					tl->print(tl->user, "Too many words."NL);
+					return FALSE;
+				}
 				p->tokens[cur_tp++] = T_ARG_UINT;
 				p->tokens[cur_tp++] = cur_bufsize;
 				memcpy(p->buf + cur_bufsize, &arg_uint, sizeof(uint32_t));
@@ -589,12 +601,20 @@ static int tokenize(t_tokenline *tl, int *words, int num_words,
 						return FALSE;
 					}
 				}
+				if (!(cur_tp + 2 < TL_MAX_WORDS)){
+					tl->print(tl->user, "Too many words."NL);
+					return FALSE;
+				}
 				p->tokens[cur_tp++] = T_ARG_FLOAT;
 				p->tokens[cur_tp++] = cur_bufsize;
 				memcpy(p->buf + cur_bufsize, &arg_float, sizeof(float));
 				cur_bufsize += sizeof(float);
 				break;
 			case T_ARG_STRING:
+				if (!(cur_tp + 2 < TL_MAX_WORDS)){
+					tl->print(tl->user, "Too many words."NL);
+					return FALSE;
+				}
 				p->tokens[cur_tp++] = T_ARG_STRING;
 				if (word[0] != '"') {
 					p->tokens[cur_tp++] = cur_bufsize;
@@ -610,6 +630,10 @@ static int tokenize(t_tokenline *tl, int *words, int num_words,
 				break;
 			case T_ARG_TOKEN:
 				if ((t_idx = find_token(arg_tokens, tl->token_dict, word)) > -1) {
+					if (!(cur_tp + 1 < TL_MAX_WORDS)){
+						tl->print(tl->user, "Too many words."NL);
+						return FALSE;
+					}
 					p->tokens[cur_tp++] = arg_tokens[t_idx].token;
 					p->last_token_entry = &arg_tokens[t_idx];
 				} else {
@@ -868,7 +892,8 @@ static void complete(t_tokenline *tl)
 					} else {
 						for (i = strlen(word); i < strlen(tl->token_dict[partial->token].tokenstr); i++)
 							add_char(tl, tl->token_dict[partial->token].tokenstr[i]);
-						add_char(tl, ' ');
+							if(i+1 < TL_MAX_LINE_LEN - 1)
+								add_char(tl, ' ');
 					}
 				}
 			}

--- a/tokenline.h
+++ b/tokenline.h
@@ -20,9 +20,9 @@
 
 #include <stdint.h>
 
-#define TL_MAX_LINE_LEN         128
+#define TL_MAX_LINE_LEN         128 //=>127 input chars max
 #define TL_MAX_ESCAPE_LEN       8
-#define TL_MAX_WORDS            64
+#define TL_MAX_WORDS            64 //=>62 - 63 tokens depending on type
 #define TL_MAX_TOKEN_LEVELS     8
 #define TL_MAX_HISTORY_SIZE     512
 #define TL_TOKEN_DELIMITER      ':'

--- a/tokenline.h
+++ b/tokenline.h
@@ -20,9 +20,9 @@
 
 #include <stdint.h>
 
-#define TL_MAX_LINE_LEN         128 //=>127 input chars max
+#define TL_MAX_LINE_LEN         128
 #define TL_MAX_ESCAPE_LEN       8
-#define TL_MAX_WORDS            64 //=>62 - 63 tokens depending on type
+#define TL_MAX_WORDS            64
 #define TL_MAX_TOKEN_LEVELS     8
 #define TL_MAX_HISTORY_SIZE     512
 #define TL_TOKEN_DELIMITER      ':'


### PR DESCRIPTION
Added explicit error message when line is unable to decompress within line length constraints
Fixed Invalid command incorrect padding (--^)
Fixed overflow when pressing Tab and inserting char at the end of the line