### PR TITLE
delete char using BS(0x08) or DEL(0x7F)

### DIFF
--- a/tokenline.c
+++ b/tokenline.c
@@ -1125,8 +1125,9 @@ int tl_input(t_tokenline *tl, uint8_t c)
 		if (tl->buf_len == tl->pos)
 			complete(tl);
 		break;
+	case 0x08:
 	case 0x7f:
-		/* Backspace */
+		/* DEL and Backspace */
 		if (tl->pos)
 			line_backspace(tl);
 		break;


### PR DESCRIPTION
0x7f is delete (DEL) not backspace (BS).
DEL works well with GNU Screen, but Minicom sends BS when the backspace key is used.
This makes Minicom usable with Hydrafw.